### PR TITLE
sanitize inputs to avoid floating-point exceptions

### DIFF
--- a/agx_emulsion/model/process.py
+++ b/agx_emulsion/model/process.py
@@ -144,8 +144,8 @@ class AgXPhoto():
         # film exposure in camera and chemical development
         raw = self._expose_film(image, exposure_ev, pixel_size_um)
         if self.io.compute_film_raw: return raw
-        
-        log_raw = np.log10(raw + 1e-10)
+
+        log_raw = np.log10(np.fmax(raw, 0.0) + 1e-10)
         density_cmy = self._develop_film(log_raw, pixel_size_um)
         if self.debug.return_negative_density_cmy: return density_cmy
         

--- a/agx_emulsion/utils/spectral_upsampling.py
+++ b/agx_emulsion/utils/spectral_upsampling.py
@@ -112,7 +112,7 @@ def rgb_to_tc_b(rgb, color_space='ITU-R BT.2020', apply_cctf_decoding=False, ref
                             illuminant=illu_xy,
                             chromatic_adaptation_transform='CAT02')
     b = np.sum(xyz, axis=-1)
-    xy = xyz[...,0:2] / b[...,None]
+    xy = xyz[...,0:2] / np.fmax(b[...,None], 1e-10)
     xy = np.clip(xy,0,1)
     tc = tri2quad(xy)
     b = np.nan_to_num(b)


### PR DESCRIPTION
This PR adds proper input sanitization for a couple of operations that would otherwise cause floating-point exceptions (division by zero and log of a negative number). These caused a segfault when numba is enabled at least on macOS 15.3 (intel)