### PR TITLE
feat: remember last used directory

### DIFF
--- a/src/spektrafilm_gui/controller.py
+++ b/src/spektrafilm_gui/controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import import_module
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -17,8 +18,10 @@ from spektrafilm_gui.controller_layers import (
 )
 from spektrafilm_gui.persistence import (
     clear_saved_default_gui_state,
+    load_dialog_dir,
     load_gui_state_from_path,
     save_default_gui_state,
+    save_dialog_dir,
     save_gui_state_to_path,
 )
 from spektrafilm_gui.state import PROJECT_DEFAULT_GUI_STATE, digest_after_selection, gui_state_from_params
@@ -44,6 +47,29 @@ QFileDialog = QtWidgets.QFileDialog
 QMessageBox = QtWidgets.QMessageBox
 SimulationRequest = runtime.SimulationRequest
 SimulationResult = runtime.SimulationResult
+
+
+class _DirMemoryDialog:
+    """Wraps QFileDialog to open in the last-used directory via QSettings."""
+
+    def __init__(self, key: str) -> None:
+        self._key = key
+
+    def get_save_file_name(self, parent, title, filename, file_filter):
+        last_dir = load_dialog_dir(self._key)
+        initial = str(Path(last_dir) / Path(filename).name) if last_dir else filename
+        path, fmt = QFileDialog.getSaveFileName(parent, title, initial, file_filter)
+        if path:
+            save_dialog_dir(self._key, str(Path(path).parent))
+        return path, fmt
+
+    def get_open_file_name(self, parent, title, _initial, file_filter):
+        path, fmt = QFileDialog.getOpenFileName(
+            parent, title, load_dialog_dir(self._key), file_filter
+        )
+        if path:
+            save_dialog_dir(self._key, str(Path(path).parent))
+        return path, fmt
 
 
 class _LazyModuleProxy:
@@ -221,7 +247,7 @@ class GuiController:
             QMessageBox.warning(dialog_parent(self._viewer), 'Save output', 'Run a simulation before saving the output layer.')
             return
 
-        filepath, _ = QFileDialog.getSaveFileName(
+        filepath, _ = _DirMemoryDialog('save_output').get_save_file_name(
             dialog_parent(self._viewer),
             'Save output image',
             'output.png',
@@ -282,7 +308,7 @@ class GuiController:
         persistence_actions.save_current_state_to_file(
             viewer=self._viewer,
             widgets=self._widgets,
-            file_dialog=QFileDialog,
+            file_dialog=_DirMemoryDialog('gui_state'),
             collect_gui_state_fn=collect_gui_state,
             save_gui_state_to_path_fn=save_gui_state_to_path,
             set_status_fn=set_status,
@@ -294,7 +320,7 @@ class GuiController:
         persistence_actions.load_state_from_file(
             viewer=self._viewer,
             widgets=self._widgets,
-            file_dialog=QFileDialog,
+            file_dialog=_DirMemoryDialog('gui_state'),
             load_gui_state_from_path_fn=load_gui_state_from_path,
             apply_gui_state_fn=apply_gui_state,
             sync_canvas_background_fn=self._sync_canvas_background,

--- a/src/spektrafilm_gui/controller_persistence.py
+++ b/src/spektrafilm_gui/controller_persistence.py
@@ -35,7 +35,7 @@ def save_current_state_to_file(
     dialog_parent_fn: Callable[[Any], Any],
     message_box: Any,
 ) -> None:
-    filepath, _ = file_dialog.getSaveFileName(
+    filepath, _ = file_dialog.get_save_file_name(
         dialog_parent_fn(viewer),
         'Save GUI state',
         'gui_state.json',
@@ -66,7 +66,7 @@ def load_state_from_file(
     dialog_parent_fn: Callable[[Any], Any],
     message_box: Any,
 ) -> None:
-    filepath, _ = file_dialog.getOpenFileName(
+    filepath, _ = file_dialog.get_open_file_name(
         dialog_parent_fn(viewer),
         'Load GUI state',
         '',

--- a/src/spektrafilm_gui/persistence.py
+++ b/src/spektrafilm_gui/persistence.py
@@ -79,11 +79,11 @@ def _deserialize_dataclass(cls: type[GuiStateType], data: dict[str, Any]) -> Gui
 
 
 def load_dialog_dir(key: str) -> str:
-    return QSettings().value(f'dialog_dirs/{key}', '')
+    return QSettings('spektrafilm', 'spektrafilm').value(f'dialog_dirs/{key}', '')
 
 
 def save_dialog_dir(key: str, directory: str) -> None:
-    QSettings().setValue(f'dialog_dirs/{key}', directory)
+    QSettings('spektrafilm', 'spektrafilm').setValue(f'dialog_dirs/{key}', directory)
 
 
 def _deserialize_value(annotation: Any, value: Any) -> Any:

--- a/src/spektrafilm_gui/persistence.py
+++ b/src/spektrafilm_gui/persistence.py
@@ -5,7 +5,7 @@ from dataclasses import asdict, fields, is_dataclass
 from pathlib import Path
 from typing import Any, TypeVar, get_origin, get_type_hints
 
-from qtpy.QtCore import QStandardPaths
+from qtpy.QtCore import QSettings, QStandardPaths
 
 from spektrafilm_gui.state import GuiState, PROJECT_DEFAULT_GUI_STATE, clone_gui_state
 
@@ -76,6 +76,14 @@ def _deserialize_dataclass(cls: type[GuiStateType], data: dict[str, Any]) -> Gui
             raise ValueError(f"Missing field {field_name!r} in {cls.__name__}.")
         values[field_name] = _deserialize_value(type_hints[field_name], data[field_name])
     return cls(**values)
+
+
+def load_dialog_dir(key: str) -> str:
+    return QSettings().value(f'dialog_dirs/{key}', '')
+
+
+def save_dialog_dir(key: str, directory: str) -> None:
+    QSettings().setValue(f'dialog_dirs/{key}', directory)
 
 
 def _deserialize_value(annotation: Any, value: Any) -> Any:

--- a/src/spektrafilm_gui/widget_sections.py
+++ b/src/spektrafilm_gui/widget_sections.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import fields
+from pathlib import Path
 from typing import Any, get_args, get_origin, get_type_hints
 
 from qtpy import QtCore, QtWidgets
@@ -30,6 +31,7 @@ from spektrafilm_gui.state import (
     SimulationState,
     SpecialState,
 )
+from spektrafilm_gui.persistence import load_dialog_dir, save_dialog_dir
 from spektrafilm_gui.theme_palette import SIZE_FOOTER_ITEM_SPACING
 from spektrafilm_gui.widget_editors import BoolEditor, EnumEditor, FloatEditor, FloatTupleEditor, IntEditor, IntTupleEditor
 from spektrafilm_gui.widget_primitives import CollapsibleSection, normalize_ui_text as _normalize_ui_text
@@ -340,9 +342,10 @@ class LoadRawSection(DataclassSection):
         form.addRow(self.reprocess_button)
 
     def _choose_file(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, _normalize_ui_text('Select input raw'))
+        path, _ = QFileDialog.getOpenFileName(self, _normalize_ui_text('Select input raw'), load_dialog_dir('raw_input'))
         if not path:
             return
+        save_dialog_dir('raw_input', str(Path(path).parent))
         self.set_path(path)
         self.load_requested.emit(path)
 
@@ -471,9 +474,10 @@ class FilePickerSection(QWidget):
         _set_single_collapsible_layout(self, 'Import RGB', content)
 
     def _choose_file(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, _normalize_ui_text('Select input image'))
+        path, _ = QFileDialog.getOpenFileName(self, _normalize_ui_text('Select input image'), load_dialog_dir('rgb_input'))
         if not path:
             return
+        save_dialog_dir('rgb_input', str(Path(path).parent))
         self.file_path.setText(path)
         self.load_requested.emit(path)
 

--- a/tests/gui/test_controller_output.py
+++ b/tests/gui/test_controller_output.py
@@ -42,6 +42,8 @@ def _configure_save_output(monkeypatch, controller: GuiController, output_layer:
     monkeypatch.setattr(controller, '_output_layer', lambda: output_layer)
     monkeypatch.setattr(controller_module, 'dialog_parent', lambda viewer: None)
     monkeypatch.setattr(controller_module, 'set_status', lambda viewer, message: captured.setdefault('status', message))
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '')
+    monkeypatch.setattr(controller_module, 'save_dialog_dir', lambda key, directory: None)
     monkeypatch.setattr(
         controller_module.QFileDialog,
         'getSaveFileName',

--- a/tests/gui/test_controller_persistence.py
+++ b/tests/gui/test_controller_persistence.py
@@ -12,6 +12,8 @@ def test_load_state_from_file_syncs_canvas_background(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(controller_module.QFileDialog, 'getOpenFileName', staticmethod(lambda *args, **kwargs: ('state.json', 'JSON (*.json)')))
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '')
+    monkeypatch.setattr(controller_module, 'save_dialog_dir', lambda key, directory: None)
     monkeypatch.setattr(controller_module, 'load_gui_state_from_path', lambda path: PROJECT_DEFAULT_GUI_STATE)
     monkeypatch.setattr(controller_module, 'apply_gui_state', lambda state, *, widgets: captured.setdefault('applied', (state, widgets)))
     monkeypatch.setattr(controller, '_sync_canvas_background', lambda: captured.setdefault('canvas_synced', True))
@@ -60,6 +62,8 @@ def test_save_current_state_to_file_persists_json(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(controller_module, 'dialog_parent', lambda viewer: None)
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '')
+    monkeypatch.setattr(controller_module, 'save_dialog_dir', lambda key, directory: None)
     monkeypatch.setattr(
         controller_module.QFileDialog,
         'getSaveFileName',
@@ -81,6 +85,8 @@ def test_load_state_from_file_applies_loaded_state(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(controller_module, 'dialog_parent', lambda viewer: None)
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '')
+    monkeypatch.setattr(controller_module, 'save_dialog_dir', lambda key, directory: None)
     monkeypatch.setattr(
         controller_module.QFileDialog,
         'getOpenFileName',

--- a/tests/gui/test_controller_persistence_module.py
+++ b/tests/gui/test_controller_persistence_module.py
@@ -18,10 +18,10 @@ class FakeFileDialog:
         self.save_result = save_result
         self.open_result = open_result
 
-    def getSaveFileName(self, *args, **kwargs):  # noqa: N802 - Qt API name
+    def get_save_file_name(self, *args, **kwargs):
         return self.save_result
 
-    def getOpenFileName(self, *args, **kwargs):  # noqa: N802 - Qt API name
+    def get_open_file_name(self, *args, **kwargs):
         return self.open_result
 
 

--- a/tests/gui/test_dir_memory_dialog.py
+++ b/tests/gui/test_dir_memory_dialog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from spektrafilm_gui import controller as controller_module
 from spektrafilm_gui.controller import _DirMemoryDialog
 
@@ -20,7 +22,7 @@ def test_get_save_file_name_combines_remembered_dir_with_filename(monkeypatch) -
 
     _DirMemoryDialog('k').get_save_file_name(None, '', 'output.png', '')
 
-    assert captured['initial'] == '/remembered/dir/output.png'
+    assert Path(captured['initial']) == Path('/remembered/dir/output.png')
 
 
 def test_get_save_file_name_uses_filename_when_no_dir(monkeypatch) -> None:
@@ -58,7 +60,7 @@ def test_get_save_file_name_stores_parent_dir(monkeypatch) -> None:
 
     _DirMemoryDialog('k').get_save_file_name(None, '', 'out.png', '')
 
-    assert captured['dir'] == '/some/dir'
+    assert Path(captured['dir']) == Path('/some/dir')
 
 
 def test_get_save_file_name_does_not_store_on_cancel(monkeypatch) -> None:

--- a/tests/gui/test_dir_memory_dialog.py
+++ b/tests/gui/test_dir_memory_dialog.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from spektrafilm_gui import controller as controller_module
+from spektrafilm_gui.controller import _DirMemoryDialog
+
+
+def test_get_save_file_name_combines_remembered_dir_with_filename(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '/remembered/dir')
+    monkeypatch.setattr(controller_module, 'save_dialog_dir', lambda key, directory: None)
+    monkeypatch.setattr(
+        controller_module.QFileDialog,
+        'getSaveFileName',
+        staticmethod(
+            lambda parent, title, initial, fmt:
+            captured.update({'initial': initial}) or ('/remembered/dir/output.png', fmt)
+        ),
+    )
+
+    _DirMemoryDialog('k').get_save_file_name(None, '', 'output.png', '')
+
+    assert captured['initial'] == '/remembered/dir/output.png'
+
+
+def test_get_save_file_name_uses_filename_when_no_dir(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '')
+    monkeypatch.setattr(controller_module, 'save_dialog_dir', lambda key, directory: None)
+    monkeypatch.setattr(
+        controller_module.QFileDialog,
+        'getSaveFileName',
+        staticmethod(
+            lambda parent, title, initial, fmt:
+            captured.update({'initial': initial}) or ('output.png', fmt)
+        ),
+    )
+
+    _DirMemoryDialog('k').get_save_file_name(None, '', 'output.png', '')
+
+    assert captured['initial'] == 'output.png'
+
+
+def test_get_save_file_name_stores_parent_dir(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '')
+    monkeypatch.setattr(
+        controller_module, 'save_dialog_dir',
+        lambda key, directory: captured.update({'dir': directory}),
+    )
+    monkeypatch.setattr(
+        controller_module.QFileDialog,
+        'getSaveFileName',
+        staticmethod(lambda *a, **kw: ('/some/dir/out.png', '')),
+    )
+
+    _DirMemoryDialog('k').get_save_file_name(None, '', 'out.png', '')
+
+    assert captured['dir'] == '/some/dir'
+
+
+def test_get_save_file_name_does_not_store_on_cancel(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '')
+    monkeypatch.setattr(
+        controller_module, 'save_dialog_dir',
+        lambda key, directory: captured.update({'called': True}),
+    )
+    monkeypatch.setattr(
+        controller_module.QFileDialog,
+        'getSaveFileName',
+        staticmethod(lambda *a, **kw: ('', '')),
+    )
+
+    _DirMemoryDialog('k').get_save_file_name(None, '', 'out.png', '')
+
+    assert 'called' not in captured
+
+
+def test_get_open_file_name_passes_remembered_dir(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '/last/dir')
+    monkeypatch.setattr(controller_module, 'save_dialog_dir', lambda key, directory: None)
+    monkeypatch.setattr(
+        controller_module.QFileDialog,
+        'getOpenFileName',
+        staticmethod(
+            lambda parent, title, initial, fmt:
+            captured.update({'initial': initial}) or ('/last/dir/f.raw', fmt)
+        ),
+    )
+
+    _DirMemoryDialog('k').get_open_file_name(None, '', '', '')
+
+    assert captured['initial'] == '/last/dir'
+
+
+def test_get_open_file_name_does_not_store_on_cancel(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(controller_module, 'load_dialog_dir', lambda key: '')
+    monkeypatch.setattr(
+        controller_module, 'save_dialog_dir',
+        lambda key, directory: captured.update({'called': True}),
+    )
+    monkeypatch.setattr(
+        controller_module.QFileDialog,
+        'getOpenFileName',
+        staticmethod(lambda *a, **kw: ('', '')),
+    )
+
+    _DirMemoryDialog('k').get_open_file_name(None, '', '', '')
+
+    assert 'called' not in captured


### PR DESCRIPTION
It was required to traverse the filesystem when loading RAW/RGB, exporting preview, or manipulating configuration.

Individual paths/dirs are persisted by default to the `$HOME/.config/napari/napari.conf` file.