### PR TITLE
Fix film format slider state handling

### DIFF
--- a/src/spektrafilm_gui/options.py
+++ b/src/spektrafilm_gui/options.py
@@ -53,10 +53,10 @@ class DiffusionFilterFamilies(Enum):
 
 
 class FilmFormats(Enum):
-    f8mm = "8 mm"
-    f16mm = "16 mm"
-    f35mm = "35 mm"
-    f60mm = "60 mm"
-    f70mm = "70 mm"
-    f90mm = "90 mm"
-    f120mm = "120 mm"
+    f8mm = "8"
+    f16mm = "16"
+    f35mm = "35"
+    f60mm = "60"
+    f70mm = "70"
+    f90mm = "90"
+    f120mm = "120"

--- a/src/spektrafilm_gui/options.py
+++ b/src/spektrafilm_gui/options.py
@@ -50,13 +50,3 @@ class DiffusionFilterFamilies(Enum):
     black_pro_mist = "black_pro_mist"
     pro_mist = "pro_mist"
     cinebloom = "cinebloom"
-
-
-class FilmFormats(Enum):
-    f8mm = "8"
-    f16mm = "16"
-    f35mm = "35"
-    f60mm = "60"
-    f70mm = "70"
-    f90mm = "90"
-    f120mm = "120"

--- a/src/spektrafilm_gui/params_mapper.py
+++ b/src/spektrafilm_gui/params_mapper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from spektrafilm_gui.state import GuiState, normalize_film_format_mm
+from spektrafilm_gui.state import GuiState
 from spektrafilm.runtime.api import init_params
 from spektrafilm.runtime.params_schema import RuntimePhotoParams
 
@@ -60,7 +60,7 @@ def _apply_camera(params: RuntimePhotoParams, state: GuiState) -> None:
     params.camera.exposure_compensation_ev = state.simulation.exposure_compensation_ev
     params.camera.auto_exposure = state.simulation.auto_exposure
     params.camera.auto_exposure_method = state.simulation.auto_exposure_method
-    params.camera.film_format_mm = float(normalize_film_format_mm(state.simulation.film_format_mm))
+    params.camera.film_format_mm = state.simulation.film_format_mm
     params.camera.filter_uv = state.input_image.filter_uv
     params.camera.filter_ir = state.input_image.filter_ir
 

--- a/src/spektrafilm_gui/params_mapper.py
+++ b/src/spektrafilm_gui/params_mapper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from spektrafilm_gui.state import GuiState
+from spektrafilm_gui.state import GuiState, normalize_film_format_mm
 from spektrafilm.runtime.api import init_params
 from spektrafilm.runtime.params_schema import RuntimePhotoParams
 
@@ -60,7 +60,7 @@ def _apply_camera(params: RuntimePhotoParams, state: GuiState) -> None:
     params.camera.exposure_compensation_ev = state.simulation.exposure_compensation_ev
     params.camera.auto_exposure = state.simulation.auto_exposure
     params.camera.auto_exposure_method = state.simulation.auto_exposure_method
-    params.camera.film_format_mm = float(state.simulation.film_format_mm.split()[0])
+    params.camera.film_format_mm = float(normalize_film_format_mm(state.simulation.film_format_mm))
     params.camera.filter_uv = state.input_image.filter_uv
     params.camera.filter_ir = state.input_image.filter_ir
 

--- a/src/spektrafilm_gui/state.py
+++ b/src/spektrafilm_gui/state.py
@@ -9,11 +9,20 @@ from spektrafilm.runtime.params_schema import RuntimePhotoParams
 from spektrafilm_gui.options import FilmFormats
 
 
-_FILM_FORMAT_MM = {float(m.value.split()[0]): m.value for m in FilmFormats}
+_FILM_FORMAT_MM = {float(m.value): m.value for m in FilmFormats}
 
 
-def _closest_film_format(mm: float) -> str:
+def _closest_film_format(mm: float) -> float:
     return min(_FILM_FORMAT_MM, key=lambda k: abs(k - mm))
+
+
+def normalize_film_format_mm(value: str | float | int) -> str:
+    if isinstance(value, str):
+        raw_value = value.strip()
+        if raw_value.endswith('mm'):
+            raw_value = raw_value[:-2].strip()
+        value = float(raw_value)
+    return _FILM_FORMAT_MM[_closest_film_format(float(value))]
 
 
 StateSection = TypeVar('StateSection')
@@ -297,7 +306,7 @@ def gui_state_from_params(
         ),
         simulation=SimulationState(
             film_stock=film_stock,
-            film_format_mm=_FILM_FORMAT_MM[_closest_film_format(params.camera.film_format_mm)],
+            film_format_mm=normalize_film_format_mm(params.camera.film_format_mm),
             camera_lens_blur_um=params.camera.lens_blur_um,
             camera_diffusion_filter_active=bool(params.camera.diffusion_filter.active),
             camera_diffusion_filter_family=params.camera.diffusion_filter.filter_family,

--- a/src/spektrafilm_gui/state.py
+++ b/src/spektrafilm_gui/state.py
@@ -6,23 +6,6 @@ from typing import TypeVar
 from spektrafilm.model.stocks import FilmStocks, PrintPapers
 from spektrafilm.runtime.api import digest_params, init_params
 from spektrafilm.runtime.params_schema import RuntimePhotoParams
-from spektrafilm_gui.options import FilmFormats
-
-
-_FILM_FORMAT_MM = {float(m.value): m.value for m in FilmFormats}
-
-
-def _closest_film_format(mm: float) -> float:
-    return min(_FILM_FORMAT_MM, key=lambda k: abs(k - mm))
-
-
-def normalize_film_format_mm(value: str | float | int) -> str:
-    if isinstance(value, str):
-        raw_value = value.strip()
-        if raw_value.endswith('mm'):
-            raw_value = raw_value[:-2].strip()
-        value = float(raw_value)
-    return _FILM_FORMAT_MM[_closest_film_format(float(value))]
 
 
 StateSection = TypeVar('StateSection')
@@ -129,7 +112,7 @@ class SpecialState:
 @dataclass(slots=True)
 class SimulationState:
     film_stock: str
-    film_format_mm: str
+    film_format_mm: float
     camera_lens_blur_um: float
     camera_diffusion_filter_active: bool
     camera_diffusion_filter_family: str
@@ -306,7 +289,7 @@ def gui_state_from_params(
         ),
         simulation=SimulationState(
             film_stock=film_stock,
-            film_format_mm=normalize_film_format_mm(params.camera.film_format_mm),
+            film_format_mm=float(params.camera.film_format_mm),
             camera_lens_blur_um=params.camera.lens_blur_um,
             camera_diffusion_filter_active=bool(params.camera.diffusion_filter.active),
             camera_diffusion_filter_family=params.camera.diffusion_filter.filter_family,

--- a/src/spektrafilm_gui/widget_sections.py
+++ b/src/spektrafilm_gui/widget_sections.py
@@ -42,6 +42,52 @@ def _enum_values(enum_cls):
     return [member.value for member in enum_cls]
 
 
+def _film_format_value(value: str | float | int) -> float:
+    if isinstance(value, str):
+        return float(value.strip().split()[0])
+    return float(value)
+
+
+def _film_format_label(value: float) -> str:
+    return f'{value:g} mm'
+
+
+class FilmFormatSliderEditor(QWidget):
+    valueChanged = Signal(str)
+
+    def __init__(self, *, minimum: float, maximum: float, step: float, decimals: int, suffix: str):
+        super().__init__()
+        self._slider = SliderFloatEditor(minimum=minimum, maximum=maximum, step=step, decimals=decimals, suffix=suffix)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._slider)
+        self._slider.valueChanged.connect(self._emit_value_changed)
+
+    @property
+    def value(self) -> str:
+        return _film_format_label(self._slider.value)
+
+    @value.setter
+    def value(self, value: str | float | int) -> None:
+        self._slider.value = _film_format_value(value)
+
+    def setMinimum(self, value: float) -> None:  # noqa: N802 - Qt API name
+        self._slider.setMinimum(value)
+
+    def setMaximum(self, value: float) -> None:  # noqa: N802 - Qt API name
+        self._slider.setMaximum(value)
+
+    def setSingleStep(self, value: float) -> None:  # noqa: N802 - Qt API name
+        self._slider.setSingleStep(value)
+
+    def setToolTip(self, text: str) -> None:  # noqa: N802 - Qt API name
+        super().setToolTip(text)
+        self._slider.setToolTip(text)
+
+    def _emit_value_changed(self, _value: float) -> None:
+        self.valueChanged.emit(self.value)
+
+
 def _build_collapsible_form_section(
     title: str,
     form: QFormLayout,
@@ -646,7 +692,7 @@ class SimulationSection(DataclassSection):
 
     def _build_editor(self, field_name: str, annotation: Any) -> QWidget:
         if field_name == 'film_format_mm':
-            return SliderFloatEditor(minimum=8.0, maximum=120.0, step=1.0, decimals=0, suffix=' mm')
+            return FilmFormatSliderEditor(minimum=8.0, maximum=120.0, step=1.0, decimals=0, suffix=' mm')
         return super()._build_editor(field_name, annotation)
 
     def _init_extra_widgets(self) -> None:

--- a/src/spektrafilm_gui/widget_sections.py
+++ b/src/spektrafilm_gui/widget_sections.py
@@ -33,59 +33,13 @@ from spektrafilm_gui.state import (
 )
 from spektrafilm_gui.persistence import load_dialog_dir, save_dialog_dir
 from spektrafilm_gui.theme_palette import SIZE_FOOTER_ITEM_SPACING
-from spektrafilm_gui.widget_editors import BoolEditor, EnumEditor, FloatEditor, FloatTupleEditor, IntEditor, IntTupleEditor, ProfileEnumEditor, SliderFloatEditor
+from spektrafilm_gui.widget_editors import BoolEditor, EnumEditor, FloatEditor, FloatTupleEditor, IntEditor, IntTupleEditor, ProfileEnumEditor
 from spektrafilm_gui.widget_primitives import CollapsibleSection, normalize_ui_text as _normalize_ui_text
 from spektrafilm_gui.widget_specs import GUI_SECTION_ENUMS, get_auxiliary_spec, get_button_spec, get_widget_spec
 
 
 def _enum_values(enum_cls):
     return [member.value for member in enum_cls]
-
-
-def _film_format_value(value: str | float | int) -> float:
-    if isinstance(value, str):
-        return float(value.strip().split()[0])
-    return float(value)
-
-
-def _film_format_label(value: float) -> str:
-    return f'{value:g} mm'
-
-
-class FilmFormatSliderEditor(QWidget):
-    valueChanged = Signal(str)
-
-    def __init__(self, *, minimum: float, maximum: float, step: float, decimals: int, suffix: str):
-        super().__init__()
-        self._slider = SliderFloatEditor(minimum=minimum, maximum=maximum, step=step, decimals=decimals, suffix=suffix)
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._slider)
-        self._slider.valueChanged.connect(self._emit_value_changed)
-
-    @property
-    def value(self) -> str:
-        return _film_format_label(self._slider.value)
-
-    @value.setter
-    def value(self, value: str | float | int) -> None:
-        self._slider.value = _film_format_value(value)
-
-    def setMinimum(self, value: float) -> None:  # noqa: N802 - Qt API name
-        self._slider.setMinimum(value)
-
-    def setMaximum(self, value: float) -> None:  # noqa: N802 - Qt API name
-        self._slider.setMaximum(value)
-
-    def setSingleStep(self, value: float) -> None:  # noqa: N802 - Qt API name
-        self._slider.setSingleStep(value)
-
-    def setToolTip(self, text: str) -> None:  # noqa: N802 - Qt API name
-        super().setToolTip(text)
-        self._slider.setToolTip(text)
-
-    def _emit_value_changed(self, _value: float) -> None:
-        self.valueChanged.emit(self.value)
 
 
 def _build_collapsible_form_section(
@@ -689,11 +643,6 @@ class SimulationSection(DataclassSection):
                 'saving_cctf_encoding',
             },
         )
-
-    def _build_editor(self, field_name: str, annotation: Any) -> QWidget:
-        if field_name == 'film_format_mm':
-            return FilmFormatSliderEditor(minimum=8.0, maximum=120.0, step=1.0, decimals=0, suffix=' mm')
-        return super()._build_editor(field_name, annotation)
 
     def _init_extra_widgets(self) -> None:
         self._glare_section = None

--- a/src/spektrafilm_gui/widget_sections.py
+++ b/src/spektrafilm_gui/widget_sections.py
@@ -30,6 +30,7 @@ from spektrafilm_gui.state import (
     PreflashingState,
     SimulationState,
     SpecialState,
+    normalize_film_format_mm,
 )
 from spektrafilm_gui.persistence import load_dialog_dir, save_dialog_dir
 from spektrafilm_gui.theme_palette import SIZE_FOOTER_ITEM_SPACING
@@ -297,7 +298,10 @@ class DataclassSection(QWidget):
     def set_state(self, state: Any) -> None:
         for field_info in fields(self._state_cls):
             field_name = field_info.name
-            getattr(self, field_name).value = getattr(state, field_name)
+            value = getattr(state, field_name)
+            if self._section_name == 'simulation' and field_name == 'film_format_mm':
+                value = normalize_film_format_mm(value)
+            getattr(self, field_name).value = value
 
     def get_state(self) -> Any:
         values = {field_info.name: getattr(self, field_info.name).value for field_info in fields(self._state_cls)}

--- a/src/spektrafilm_gui/widget_sections.py
+++ b/src/spektrafilm_gui/widget_sections.py
@@ -30,7 +30,6 @@ from spektrafilm_gui.state import (
     PreflashingState,
     SimulationState,
     SpecialState,
-    normalize_film_format_mm,
 )
 from spektrafilm_gui.persistence import load_dialog_dir, save_dialog_dir
 from spektrafilm_gui.theme_palette import SIZE_FOOTER_ITEM_SPACING
@@ -298,10 +297,7 @@ class DataclassSection(QWidget):
     def set_state(self, state: Any) -> None:
         for field_info in fields(self._state_cls):
             field_name = field_info.name
-            value = getattr(state, field_name)
-            if self._section_name == 'simulation' and field_name == 'film_format_mm':
-                value = normalize_film_format_mm(value)
-            getattr(self, field_name).value = value
+            getattr(self, field_name).value = getattr(state, field_name)
 
     def get_state(self) -> Any:
         values = {field_info.name: getattr(self, field_info.name).value for field_info in fields(self._state_cls)}

--- a/src/spektrafilm_gui/widget_specs.py
+++ b/src/spektrafilm_gui/widget_specs.py
@@ -6,7 +6,6 @@ from enum import Enum
 from spektrafilm_gui.options import (
     AutoExposureMethods,
     DiffusionFilterFamilies,
-    FilmFormats,
     NapariInterpolationModes,
     RGBColorSpaces,
     RGBtoRAWMethod,
@@ -46,7 +45,6 @@ GUI_SECTION_ENUMS: dict[str, dict[str, type[Enum]]] = {
     },
     "simulation": {
         "film_stock": FilmStocks,
-        "film_format_mm": FilmFormats,
         "auto_exposure_method": AutoExposureMethods,
         "camera_diffusion_filter_family": DiffusionFilterFamilies,
         "print_paper": PrintPapers,
@@ -73,11 +71,12 @@ GUI_WIDGET_SPECS = {
             tooltip="Use the auto-exposure feature of the virtual camera",
         ),
         "film_format_mm": WidgetSpec(
-            label="Film format",
+            label="Film format mm",
             tooltip="Long edge of the film format in millimeters, e.g. 8, 16, 35, 60, 120",
             min_value=8.0,
             max_value=120.0,
             step=1.0,
+            decimals=0,
         ),
         "camera_lens_blur_um": WidgetSpec(
             label="Camera lens blur um",

--- a/src/spektrafilm_gui/widget_specs.py
+++ b/src/spektrafilm_gui/widget_specs.py
@@ -73,8 +73,8 @@ GUI_WIDGET_SPECS = {
             tooltip="Use the auto-exposure feature of the virtual camera",
         ),
         "film_format_mm": WidgetSpec(
-            label="Film format mm",
-            tooltip="Long edge of the film format in millimeters, e.g. 8mm Super8, 16mm, 35mm, 60mm, 120mm",
+            label="Film format",
+            tooltip="Long edge of the film format in millimeters, e.g. 8, 16, 35, 60, 120",
             min_value=8.0,
             max_value=120.0,
             step=1.0,

--- a/tests/gui/test_params_mapper.py
+++ b/tests/gui/test_params_mapper.py
@@ -108,15 +108,6 @@ def test_build_params_maps_runtime_strings() -> None:
     assert params.io.output_cctf_encoding is True
 
 
-def test_build_params_accepts_legacy_film_format_unit_strings() -> None:
-    state = make_state()
-    state.simulation.film_format_mm = '35 mm'
-
-    params = build_params_from_state(state)
-
-    assert params.camera.film_format_mm == 35.0
-
-
 def test_build_params_maps_enlarger_diffusion_filter() -> None:
     state = make_state()
     state.simulation.diffusion_filter_active = True

--- a/tests/gui/test_params_mapper.py
+++ b/tests/gui/test_params_mapper.py
@@ -108,6 +108,15 @@ def test_build_params_maps_runtime_strings() -> None:
     assert params.io.output_cctf_encoding is True
 
 
+def test_build_params_accepts_legacy_film_format_unit_strings() -> None:
+    state = make_state()
+    state.simulation.film_format_mm = '35 mm'
+
+    params = build_params_from_state(state)
+
+    assert params.camera.film_format_mm == 35.0
+
+
 def test_build_params_maps_enlarger_diffusion_filter() -> None:
     state = make_state()
     state.simulation.diffusion_filter_active = True

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -410,7 +410,7 @@ def test_simulation_section_profile_use_badges_follow_selected_profiles() -> Non
     assert widget_editors_module.ProfileEnumEditor.display_text_for_value('kodak_2393') == 'cine / kodak_2393'
 
 
-def test_simulation_section_round_trips_string_film_format_with_slider() -> None:
+def test_simulation_section_uses_film_format_enum_for_string_state() -> None:
     os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
     from qtpy import QtWidgets
 
@@ -421,5 +421,6 @@ def test_simulation_section_round_trips_string_film_format_with_slider() -> None
 
     section.set_state(state)
 
+    assert isinstance(section.film_format_mm, widget_editors_module.EnumEditor)
     assert section.film_format_mm.value == '35 mm'
     assert section.get_state().film_format_mm == '35 mm'

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -408,3 +408,18 @@ def test_simulation_section_profile_use_badges_follow_selected_profiles() -> Non
     assert widget_editors_module.ProfileEnumEditor.display_text_for_value('kodak_portra_400') == 'still / kodak_portra_400'
     assert widget_editors_module.ProfileEnumEditor.display_text_for_value('kodak_vision3_50d') == 'cine / kodak_vision3_50d'
     assert widget_editors_module.ProfileEnumEditor.display_text_for_value('kodak_2393') == 'cine / kodak_2393'
+
+
+def test_simulation_section_round_trips_string_film_format_with_slider() -> None:
+    os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+    from qtpy import QtWidgets
+
+    _app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    section = widgets_module.SimulationSection()
+    state = state_module.clone_state_section(state_module.PROJECT_DEFAULT_GUI_STATE.simulation)
+    state.film_format_mm = '35 mm'
+
+    section.set_state(state)
+
+    assert section.film_format_mm.value == '35 mm'
+    assert section.get_state().film_format_mm == '35 mm'

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -408,19 +408,3 @@ def test_simulation_section_profile_use_badges_follow_selected_profiles() -> Non
     assert widget_editors_module.ProfileEnumEditor.display_text_for_value('kodak_portra_400') == 'still / kodak_portra_400'
     assert widget_editors_module.ProfileEnumEditor.display_text_for_value('kodak_vision3_50d') == 'cine / kodak_vision3_50d'
     assert widget_editors_module.ProfileEnumEditor.display_text_for_value('kodak_2393') == 'cine / kodak_2393'
-
-
-def test_simulation_section_uses_plain_film_format_enum_for_legacy_unit_state() -> None:
-    os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
-    from qtpy import QtWidgets
-
-    _app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
-    section = widgets_module.SimulationSection()
-    state = state_module.clone_state_section(state_module.PROJECT_DEFAULT_GUI_STATE.simulation)
-    state.film_format_mm = '35 mm'
-
-    section.set_state(state)
-
-    assert isinstance(section.film_format_mm, widget_editors_module.EnumEditor)
-    assert section.film_format_mm.value == '35'
-    assert section.get_state().film_format_mm == '35'

--- a/tests/gui/test_widgets.py
+++ b/tests/gui/test_widgets.py
@@ -410,7 +410,7 @@ def test_simulation_section_profile_use_badges_follow_selected_profiles() -> Non
     assert widget_editors_module.ProfileEnumEditor.display_text_for_value('kodak_2393') == 'cine / kodak_2393'
 
 
-def test_simulation_section_uses_film_format_enum_for_string_state() -> None:
+def test_simulation_section_uses_plain_film_format_enum_for_legacy_unit_state() -> None:
     os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
     from qtpy import QtWidgets
 
@@ -422,5 +422,5 @@ def test_simulation_section_uses_film_format_enum_for_string_state() -> None:
     section.set_state(state)
 
     assert isinstance(section.film_format_mm, widget_editors_module.EnumEditor)
-    assert section.film_format_mm.value == '35 mm'
-    assert section.get_state().film_format_mm == '35 mm'
+    assert section.film_format_mm.value == '35'
+    assert section.get_state().film_format_mm == '35'


### PR DESCRIPTION
## Summary
- Fixes the GUI startup crash when applying `SimulationState.film_format_mm` to the film format slider.
- Keeps the GUI state value in the existing string form, e.g. `35 mm`, while adapting it to the numeric slider internally.

## Details
`SimulationSection` now wraps the slider with a small film-format editor that parses the stored label before setting the slider and returns the same label format when collecting state. This keeps `params_mapper` behavior unchanged and avoids widening the state schema for this bug fix.

Fixes #31.

## Validation
- `QT_QPA_PLATFORM=offscreen .\.venv\Scripts\python.exe -m pytest tests/gui/test_widgets.py::test_simulation_section_round_trips_string_film_format_with_slider -q` -> `1 passed`
- `QT_QPA_PLATFORM=offscreen .\.venv\Scripts\python.exe -m pytest tests/gui/test_widgets.py tests/gui/test_state_bridge.py tests/gui/test_persistence.py -q` -> `22 passed`
- `QT_QPA_PLATFORM=offscreen .\.venv\Scripts\python.exe -m pytest tests/gui/test_app.py tests/gui/test_params_mapper.py -q` -> `29 passed`
- `git diff --cached --check` -> passed
- `gitleaks protect --staged --redact --verbose` -> no leaks found

Also ran the full suite with `QT_QPA_PLATFORM=offscreen .\.venv\Scripts\python.exe -m pytest -q`; it completed with `235 passed, 14 failed`. The failures were in coupler/profile/regression-baseline tests outside this GUI state handling change.